### PR TITLE
Rewrite bot: fix indicator bugs, add error handling, secrets in env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+.env
+.venv/
+venv/
+positions.json
+trading.p

--- a/config.py
+++ b/config.py
@@ -1,7 +1,28 @@
-BINANCE_API_KEY_PROD = 'you api key production'
-BINANCE_SECRET_KEY_PROD = 'you api key production'
+"""Configuration for the supertrend trading bot.
 
-BINANCE_API_KEY_TEST = 'you api key testnet'
-BINANCE_SECRET_KEY_TEST = 'you api key testnet'
+Secrets are read from environment variables so they aren't checked into git.
+Set BINANCE_API_KEY_PROD / BINANCE_SECRET_KEY_PROD for live trading and
+BINANCE_API_KEY_TEST / BINANCE_SECRET_KEY_TEST for the sandbox.
+BOT_IS_TESTNET defaults to "true" so accidental runs hit the testnet.
+"""
 
-IS_TESTNET = True
+import os
+
+BINANCE_API_KEY_PROD = os.environ.get("BINANCE_API_KEY_PROD", "")
+BINANCE_SECRET_KEY_PROD = os.environ.get("BINANCE_SECRET_KEY_PROD", "")
+
+BINANCE_API_KEY_TEST = os.environ.get("BINANCE_API_KEY_TEST", "")
+BINANCE_SECRET_KEY_TEST = os.environ.get("BINANCE_SECRET_KEY_TEST", "")
+
+IS_TESTNET = os.environ.get("BOT_IS_TESTNET", "true").lower() == "true"
+
+SYMBOLS = [
+    "BTC/USDT", "ETH/USDT", "BNB/USDT", "NEO/USDT", "LTC/USDT", "QTUM/USDT",
+    "ADA/USDT", "XRP/USDT", "EOS/USDT", "LINK/USDT", "VET/USDT", "MATIC/USDT",
+    "DOGE/USDT", "DOT/USDT", "RSR/USDT", "SHIB/USDT", "ZIL/USDT", "ZRX/USDT",
+    "ETC/USDT", "BAKE/USDT", "SOL/USDT", "THETA/USDT", "ENJ/USDT", "DASH/USDT",
+    "KSM/USDT", "SUPER/USDT", "SUSHI/USDT", "XLM/USDT", "BADGER/USDT",
+    "CKB/USDT", "ICP/USDT", "IOTA/USDT", "ALGO/USDT", "MKR/USDT", "BCH/USDT",
+    "SAND/USDT", "CAKE/USDT", "AAVE/USDT", "KAVA/USDT", "TFUEL/USDT", "ONE/USDT",
+    "FIL/USDT", "UNI/USDT", "XMR/USDT", "BAT/USDT", "CTXC/USDT",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-ccxt
-schedule
-pandas
-warnings
-pickle
-os
-numpy 
-datetime 
-threading
-ta 
+ccxt>=4.0
+pandas>=2.0
+schedule>=1.2

--- a/supertrend.py
+++ b/supertrend.py
@@ -1,428 +1,350 @@
-import ccxt 
-from pprint import pprint
-import config
-import schedule
-import pandas as pd
-pd.set_option('display.max_rows', None)
+"""Cryptocurrency trading bot driven by three Supertrend indicators."""
 
-import warnings
-warnings.filterwarnings('ignore')
-import pickle
-import os
+from __future__ import annotations
 
-import numpy as np
-from datetime import datetime
-import time
+import json
+import logging
 import math
-import threading
+import time
+from pathlib import Path
+from typing import Optional
 
-if config.IS_TESTNET:
-    #testnet binance
-    print('CCXT version:', ccxt.__version__)  # requires CCXT version > 1.20.31
-    exchange = ccxt.binance({
-        'apiKey': config.BINANCE_API_KEY_TEST,
-        'secret': config.BINANCE_SECRET_KEY_TEST,
-        'enableRateLimit': True,
-        'options': {
-            'defaultType': 'future', 
-        },
-    })
-    exchange.set_sandbox_mode(True)
-    #response = exchange.fapiPrivateGetPositionRisk()  # <<<<<<<<<<<<<<< changed for fapiPrivateGetPositionRisk here
-    #pprint(response)
-else:
-    exchange_id = 'binance'
-    exchange_class = getattr(ccxt, exchange_id)
-    exchange = exchange_class({
-        'apiKey': config.BINANCE_API_KEY_PROD,
-        'secret': config.BINANCE_SECRET_KEY_PROD,
-    })
+import ccxt
+import pandas as pd
+import schedule
 
-markets = exchange.load_markets()
+import config
 
-def get_market(list1):
-    trade = []
-    print('getting markets')
-    for market in list1:
-        if market.split('/')[1] == 'USDT':
-            if markets[market]['info']['status'] == 'TRADING' and markets[market]['info']['isSpotTradingAllowed']: 
-                  
-                trade.append(market)
-    return trade
+LOG = logging.getLogger("supertrend_bot")
+STATE_FILE = Path("positions.json")
 
 
-def tr(data):
-    data['previous_close'] = data['close'].shift(1)
-    data['high-low'] = abs(data['high'] - data['low'])
-    data['high-pc'] = abs(data['high'] - data['previous_close'])
-    data['low-pc'] = abs(data['low'] - data['previous_close'])
+def build_exchange() -> ccxt.Exchange:
+    if config.IS_TESTNET:
+        LOG.info("Using Binance testnet (spot). CCXT %s", ccxt.__version__)
+        exchange = ccxt.binance({
+            "apiKey": config.BINANCE_API_KEY_TEST,
+            "secret": config.BINANCE_SECRET_KEY_TEST,
+            "enableRateLimit": True,
+        })
+        exchange.set_sandbox_mode(True)
+    else:
+        LOG.info("Using Binance production (spot). CCXT %s", ccxt.__version__)
+        exchange = ccxt.binance({
+            "apiKey": config.BINANCE_API_KEY_PROD,
+            "secret": config.BINANCE_SECRET_KEY_PROD,
+            "enableRateLimit": True,
+        })
+    exchange.load_markets()
+    return exchange
 
-    tr = data[['high-low', 'high-pc', 'low-pc']].max(axis=1)
 
-    return tr
-
-def atr(data, period=14):
-    data['tr'] = tr(data)
-    atr = data['tr'].rolling(period).mean()
-
-    return atr
+def true_range(data: pd.DataFrame) -> pd.Series:
+    prev_close = data["close"].shift(1)
+    h_l = (data["high"] - data["low"]).abs()
+    h_pc = (data["high"] - prev_close).abs()
+    l_pc = (data["low"] - prev_close).abs()
+    return pd.concat([h_l, h_pc, l_pc], axis=1).max(axis=1)
 
 
-def supertrend(df, period=12, atr_multiplier=3, period2 = 10, atr_multiplier2 = 1,period3 = 11, atr_multiplier3 = 2 ):
-    hl2 = (df['high'] + df['low']) / 2
-    df['atr'] = atr(df, period)
-    df['upperband'] = hl2 + (atr_multiplier * df['atr'])
-    df['lowerband'] = hl2 - (atr_multiplier * df['atr'])
+def average_true_range(data: pd.DataFrame, period: int = 14) -> pd.Series:
+    # Wilder's smoothing: EMA with alpha = 1/period.
+    return true_range(data).ewm(alpha=1 / period, adjust=False).mean()
 
-    df['atr2'] = atr(df, period2)
-    df['upperband2'] = hl2 + (atr_multiplier2 * df['atr2'])
-    df['lowerband2'] = hl2 - (atr_multiplier2 * df['atr2'])
 
-    df['atr3'] = atr(df, period3)
-    df['upperband3'] = hl2 + (atr_multiplier3 * df['atr3'])
-    df['lowerband3'] = hl2 - (atr_multiplier3 * df['atr3'])
-    df['in_uptrend'] = True
-    df['in_uptrend2'] = True
-    df['in_uptrend3'] = True
-    df['uptrend'] = True
-    df['ewma'] = df['close'].ewm(200, adjust=True).mean()
+def _apply_supertrend_band(
+    df: pd.DataFrame, period: int, multiplier: float, suffix: str
+) -> None:
+    hl2 = (df["high"] + df["low"]) / 2
+    atr_series = average_true_range(df, period)
+    upper = (hl2 + multiplier * atr_series).to_numpy().copy()
+    lower = (hl2 - multiplier * atr_series).to_numpy().copy()
+    close = df["close"].to_numpy()
 
-    for current in range(1, len(df.index)):
-        previous = current - 1
-
-        if df['close'][current] > df['upperband'][previous]:
-            df['in_uptrend'][current] = True
-
-        elif df['close'][current] < df['lowerband'][previous]:
-            df['in_uptrend'][current] = False
-
+    in_uptrend = [True] * len(df)
+    for i in range(1, len(df)):
+        if close[i] > upper[i - 1]:
+            in_uptrend[i] = True
+        elif close[i] < lower[i - 1]:
+            in_uptrend[i] = False
         else:
-            df['in_uptrend'][current] = df['in_uptrend'][previous]
+            in_uptrend[i] = in_uptrend[i - 1]
+            if in_uptrend[i] and lower[i] < lower[i - 1]:
+                lower[i] = lower[i - 1]
+            if not in_uptrend[i] and upper[i] > upper[i - 1]:
+                upper[i] = upper[i - 1]
 
-            if df['in_uptrend'][current] and df['lowerband'][current] < df['lowerband'][previous]:
-                df['lowerband'][current] = df['lowerband'][previous]
-            if not df['in_uptrend'][current] and df['upperband'][current] > df['upperband'][previous]:
-                df['upperband'][current] = df['upperband'][previous]
+    df[f"upperband{suffix}"] = upper
+    df[f"lowerband{suffix}"] = lower
+    df[f"in_uptrend{suffix}"] = in_uptrend
 
-        if df['close'][current] > df['upperband2'][previous]:
-            df['in_uptrend2'][current] = True
 
-        elif df['close'][current] < df['lowerband2'][previous]:
-            df['in_uptrend2'][current] = False
-
-        else:
-            df['in_uptrend2'][current] = df['in_uptrend2'][previous]
-
-            if df['in_uptrend2'][current] and df['lowerband2'][current] < df['lowerband2'][previous]:
-                df['lowerband2'][current] = df['lowerband2'][previous]
-            if not df['in_uptrend2'][current] and df['upperband2'][current] > df['upperband2'][previous]:
-                df['upperband2'][current] = df['upperband2'][previous]
-
-        if df['close'][current] > df['upperband3'][previous]:
-            df['in_uptrend3'][current] = True
-
-        elif df['close'][current] < df['lowerband3'][previous]:
-            df['in_uptrend3'][current] = False
-
-        else:
-            df['in_uptrend3'][current] = df['in_uptrend3'][previous]
-                
-            if df['in_uptrend3'][current] and df['lowerband3'][current] < df['lowerband3'][previous]:
-                df['lowerband3'][current] = df['lowerband3'][previous]
-
-            if not df['in_uptrend3'][current] and df['upperband3'][current] > df['upperband3'][previous]:
-                df['upperband3'][current] = df['upperband3'][previous]
-        
-        if df['in_uptrend'][current] and df['in_uptrend2'][current] and df['in_uptrend3'][current]:
-            df['uptrend'][current] = True
-            
-        else: 
-            df['uptrend'][current] = False
+def supertrend(
+    df: pd.DataFrame,
+    period: int = 12, atr_multiplier: float = 3,
+    period2: int = 10, atr_multiplier2: float = 1,
+    period3: int = 11, atr_multiplier3: float = 2,
+) -> pd.DataFrame:
+    _apply_supertrend_band(df, period, atr_multiplier, "")
+    _apply_supertrend_band(df, period2, atr_multiplier2, "2")
+    _apply_supertrend_band(df, period3, atr_multiplier3, "3")
+    df["ewma"] = df["close"].ewm(span=200, adjust=True).mean()
+    df["uptrend"] = df["in_uptrend"] & df["in_uptrend2"] & df["in_uptrend3"]
     return df
 
-def tradable_markets(list2):
-    if not os.path.exists('trading.p'):
-        print('no file creating...')
-        with open('trading.p', 'wb') as fp:
-            tradable_market = {}
-            print('getting tradable markets')
-            for market in list2:
-                
-                bars = exchange.fetch_ohlcv(market,timeframe='1h', limit=100)
-                df = pd.DataFrame(bars[:-1], columns=['timestamp','open','high','low','close','volume'])
-                df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
-        
-                tr(df)
-                
-                atr(df)
-                
-                supertrend(df)
-                    
-                tradable_market[market] = {'info':df,'in position': False}
-            pickle.dump(tradable_market, fp, protocol=pickle.HIGHEST_PROTOCOL)
+
+def load_positions() -> dict[str, bool]:
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        LOG.warning("Could not read state file (%s); starting empty", exc)
+        return {}
+
+
+def save_positions(positions: dict[str, bool]) -> None:
+    try:
+        STATE_FILE.write_text(json.dumps(positions, indent=2, sort_keys=True))
+        LOG.info("Saved state. See you in an hour.")
+    except OSError as exc:
+        LOG.error("Could not save state: %s", exc)
+
+
+def fetch_ohlcv_df(exchange: ccxt.Exchange, symbol: str) -> Optional[pd.DataFrame]:
+    try:
+        bars = exchange.fetch_ohlcv(symbol, timeframe="1h", limit=100)
+    except ccxt.BaseError as exc:
+        LOG.error("OHLCV fetch failed for %s: %s", symbol, exc)
+        return None
+    if not bars or len(bars) < 2:
+        LOG.warning("Not enough OHLCV data for %s", symbol)
+        return None
+    df = pd.DataFrame(
+        bars[:-1],
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+    supertrend(df)
+    return df
+
+
+def build_market_state(
+    exchange: ccxt.Exchange, symbols: list[str], positions: dict[str, bool]
+) -> dict[str, dict]:
+    state: dict[str, dict] = {}
+    for symbol in symbols:
+        df = fetch_ohlcv_df(exchange, symbol)
+        if df is None or df.empty:
+            continue
+        state[symbol] = {
+            "info": df,
+            "in_position": bool(positions.get(symbol, False)),
+        }
+    return state
+
+
+def safe_balance(exchange: ccxt.Exchange, asset: str) -> float:
+    try:
+        return float(exchange.fetch_balance()["free"].get(asset, 0.0))
+    except ccxt.BaseError as exc:
+        LOG.error("Balance fetch failed for %s: %s", asset, exc)
+        return 0.0
+
+
+def safe_price(exchange: ccxt.Exchange, symbol: str) -> Optional[float]:
+    try:
+        ticker = exchange.fetch_ticker(symbol)
+    except ccxt.BaseError as exc:
+        LOG.error("Ticker fetch failed for %s: %s", symbol, exc)
+        return None
+    last = ticker.get("last")
+    if last is None:
+        return None
+    try:
+        return float(last)
+    except (TypeError, ValueError):
+        return None
+
+
+def market_buy(exchange: ccxt.Exchange, symbol: str, amount: float) -> bool:
+    try:
+        qty = float(exchange.amount_to_precision(symbol, amount))
+    except (ccxt.BaseError, ValueError) as exc:
+        LOG.error("Precision rounding failed for %s: %s", symbol, exc)
+        return False
+    if qty <= 0:
+        LOG.warning("Computed buy qty <= 0 for %s; skipping", symbol)
+        return False
+    try:
+        exchange.create_market_buy_order(symbol, qty)
+    except ccxt.BaseError as exc:
+        LOG.error("Buy failed for %s: %s", symbol, exc)
+        return False
+    LOG.info("Bought %s qty=%s", symbol, qty)
+    return True
+
+
+def market_sell_all(exchange: ccxt.Exchange, symbol: str) -> bool:
+    base = symbol.split("/")[0]
+    free = safe_balance(exchange, base)
+    if free <= 0:
+        LOG.warning("No %s balance available to sell", base)
+        return False
+    try:
+        qty = float(exchange.amount_to_precision(symbol, free))
+    except (ccxt.BaseError, ValueError) as exc:
+        LOG.error("Precision rounding failed for %s: %s", symbol, exc)
+        return False
+    if qty <= 0:
+        return False
+    try:
+        exchange.create_market_sell_order(symbol, qty)
+    except ccxt.BaseError as exc:
+        LOG.error("Sell failed for %s: %s", symbol, exc)
+        return False
+    LOG.info("Sold %s qty=%s", symbol, qty)
+    return True
+
+
+def compute_allocation(exchange: ccxt.Exchange, symbols: list[str]) -> float:
+    cash = safe_balance(exchange, "USDT")
+    for symbol in symbols:
+        price = safe_price(exchange, symbol)
+        if price is None:
+            continue
+        cash += price * safe_balance(exchange, symbol.split("/")[0])
+    return cash / max(len(symbols), 1)
+
+
+def _last_two(df: pd.DataFrame) -> Optional[tuple[int, int]]:
+    if len(df) < 2:
+        return None
+    return len(df) - 1, len(df) - 2
+
+
+def exit_on_downtrend(exchange: ccxt.Exchange, state: dict[str, dict]) -> None:
+    for symbol, info in state.items():
+        if not info["in_position"]:
+            continue
+        idx = _last_two(info["info"])
+        if idx is None:
+            continue
+        last, prev = idx
+        df = info["info"]
+        if df["uptrend"].iat[prev] and not df["uptrend"].iat[last]:
+            if market_sell_all(exchange, symbol):
+                info["in_position"] = False
+                LOG.info("%s exited on downtrend", symbol)
+
+
+def exit_on_flat_band(
+    exchange: ccxt.Exchange, state: dict[str, dict], rel_tol: float = 1e-9
+) -> None:
+    for symbol, info in state.items():
+        if not info["in_position"]:
+            continue
+        idx = _last_two(info["info"])
+        if idx is None:
+            continue
+        last, prev = idx
+        df = info["info"]
+        if math.isclose(
+            df["lowerband2"].iat[last], df["lowerband2"].iat[prev], rel_tol=rel_tol
+        ):
+            if market_sell_all(exchange, symbol):
+                info["in_position"] = False
+                LOG.info("%s exited on flat lowerband2", symbol)
+
+
+def enter_on_reversal(
+    exchange: ccxt.Exchange, state: dict[str, dict], allocation: float
+) -> None:
+    for symbol, info in state.items():
+        if info["in_position"]:
+            continue
+        idx = _last_two(info["info"])
+        if idx is None:
+            continue
+        last, prev = idx
+        df = info["info"]
+        if (
+            not df["uptrend"].iat[prev]
+            and df["uptrend"].iat[last]
+            and df["close"].iat[last] > df["ewma"].iat[last]
+        ):
+            price = safe_price(exchange, symbol)
+            if price is None or price <= 0:
+                continue
+            if market_buy(exchange, symbol, allocation / price):
+                info["in_position"] = True
+
+
+def enter_on_rising_band(
+    exchange: ccxt.Exchange, state: dict[str, dict], allocation: float
+) -> None:
+    for symbol, info in state.items():
+        if info["in_position"]:
+            continue
+        idx = _last_two(info["info"])
+        if idx is None:
+            continue
+        last, prev = idx
+        df = info["info"]
+        if (
+            df["lowerband2"].iat[last] > df["lowerband2"].iat[prev]
+            and df["uptrend"].iat[last]
+            and df["uptrend"].iat[prev]
+            and df["close"].iat[last] > df["ewma"].iat[last]
+        ):
+            price = safe_price(exchange, symbol)
+            if price is None or price <= 0:
+                continue
+            if market_buy(exchange, symbol, allocation / price):
+                info["in_position"] = True
+
+
+def report_open_positions(state: dict[str, dict]) -> None:
+    open_syms = [s for s, info in state.items() if info["in_position"]]
+    if not open_syms:
+        LOG.info("Not currently in any position.")
     else:
-        with open('trading.p', 'rb') as fp:
-            print('Opening file')
-            tradable_market = pickle.load(fp)
-            for market in list2:
-                
-                bars = exchange.fetch_ohlcv(market,timeframe='1h', limit=100)
-                df = pd.DataFrame(bars[:-1], columns=['timestamp','open','high','low','close','volume'])
-                df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
-        
-                tr(df)
-                
-                atr(df)
-                
-                supertrend(df)
-                    
-                tradable_market[market]['info'] = df
-            
-    return tradable_market
-
-def tradings(dict1):
-    if not os.path.exists('trading.p'):
-        print('no file creating...')
-        with open('trading.p', 'wb') as fp:
-            trading = {}
-            for k,v in dict1.items():
-                last_row_index = len(v.index) - 1
-                previous_row_index = last_row_index - 1
-                if v['in_uptrend2'][last_row_index] and v['close'][last_row_index] > v['ewma'][last_row_index]:
-                    trading[k] = [v, True]
-            pickle.dump(trading, fp, protocol=pickle.HIGHEST_PROTOCOL)
-
-    else:
-        with open('trading.p', 'rb') as fp:
-            print('Opening file')
-            trading = pickle.load(fp)
-    return trading
+        LOG.info("Currently holding: %s", ", ".join(open_syms))
 
 
-def remove_downtrend(dict2):
-    
-
-    for k,v in dict2.items(): 
-        if v['in position']:
-            last_row_index = len(v['info'].index) - 1
-            previous_row_index = last_row_index - 1
-            if v['info']['uptrend'][previous_row_index] and not v['info']['uptrend'][last_row_index] and v['in position']:
-                
-                sell_downtrend = exchange.fetch_balance()['free'][k.split('/')[0]]
-                exchange.create_market_sell_order(k, sell_downtrend)
-                v['in position'] = False
-                print(f'{k} sold, is in a downtrend')
-           
-            
-
-
-    return dict2
-
-def length(dict3):
-    length = len(dict3)
-    return length
-
-def new_trades(dict1):
-    print('checking for new markets...')
-    count = 0
-    for k,v in dict1.items():
-        
-        last_row_index = len(v.index) - 1
-        previous_row_index = last_row_index - 1       
-        if not ['in_uptrend2'][previous_row_index] and v['in_uptrend2'][last_row_index] and v['close'][last_row_index] > v['ewma'][last_row_index]:
-            dict1[k] = [v, True]
-            count+=1
-    if count == 1:
-        print('1 market added')
-    else:
-        print(f'{count} markets added')
-    return dict1
+def run_bot(exchange: ccxt.Exchange, symbols: list[str]) -> None:
+    LOG.info("Running bot cycle...")
+    try:
+        positions = load_positions()
+        state = build_market_state(exchange, symbols, positions)
+        if not state:
+            LOG.warning("No market data fetched; skipping cycle")
+            return
+        allocation = compute_allocation(exchange, symbols)
+        LOG.info("Allocation per slot: %.4f USDT", allocation)
+        exit_on_downtrend(exchange, state)
+        exit_on_flat_band(exchange, state)
+        enter_on_reversal(exchange, state, allocation)
+        enter_on_rising_band(exchange, state, allocation)
+        save_positions({s: info["in_position"] for s, info in state.items()})
+        report_open_positions(state)
+    except Exception:
+        LOG.exception("Unhandled error during bot cycle")
 
 
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    exchange = build_exchange()
+    symbols = ["BTC/USDT", "ETH/USDT"] if config.IS_TESTNET else config.SYMBOLS
+    run_bot(exchange, symbols)
+    schedule.every().hour.at(":00").do(run_bot, exchange, symbols)
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
 
 
-def round_decimals_down(number:float, decimals:int=2):
-    """
-    Returns a value rounded down to a specific number of decimal places.
-    """
-    if not isinstance(decimals, int):
-        raise TypeError("decimal places must be an integer")
-    elif decimals < 0:
-        raise ValueError("decimal places has to be 0 or more")
-    elif decimals == 0:
-        return math.floor(number)
-
-    factor = 10 ** decimals
-    return math.floor(number * factor) / factor
-
-def allocations(list1):
-    total_cash = float(exchange.fetch_balance()['free']['USDT'])   
-    for market in list1:
-        total_cash += float(exchange.fetch_ticker(market)['info']['lastPrice']) * exchange.fetch_balance()['free'][market.split('/')[0]]
-    
-    allocation = total_cash/(len(list1) - 14)
-    return allocation
-
-
-def porfolio_management(dict2, allocation):
-    print('checking for new markets...')
-    for k,v in dict2.items():
-        last_row_index = len(v['info'].index) - 1
-        previous_row_index = last_row_index - 1  
-        if not v['in position']:
-            if not v['info']['uptrend'][previous_row_index] and v['info']['uptrend'][last_row_index] and v['info']['close'][last_row_index] > v['info']['ewma'][last_row_index]:
-                current_amount = float(exchange.fetch_ticker(k)['info']['lastPrice']) * exchange.fetch_balance()['free'][k.split('/')[0]]    
-                
-                buy_amount = allocation / float(exchange.fetch_ticker(k)['info']['lastPrice'])
-                exchange.create_market_buy_order(k, round(buy_amount,5))
-                print(f'Bought {k}')
-                v['in position'] = True
-
-def while_trading_sell(dict3):
-    print('while Trading selling')
-    for k,v in dict3.items():
-        current = len(v['info'].index) - 1    
-        previous = current - 1
-        previous_2 = current - 2
-        next1 = current + 1
-        
-
-        if v['in position'] and v['info']['lowerband2'][current] == v['info']['lowerband2'][previous]:
-            sell_downtrend = exchange.fetch_balance()['free'][k.split('/')[0]]
-            exchange.create_market_sell_order(k, sell_downtrend)
-            print(f'Sold {k}')
-            v['in position'] = False
-
-
-def while_trading_buy(dict3,allocation):
-    print('while Trading buying')
-    for k,v in dict3.items():
-        current = len(v['info'].index) - 1    
-        previous = current - 1
-        previous_2 = current - 2
-        next1 = current + 1
-
-        if not v['in position'] and v['info']['lowerband2'][current] > v['info']['lowerband2'][previous] and v['info']['uptrend'][current] and v['info']['uptrend'][previous] and v['info']['close'][current] > v['info']['ewma'][current]:
-            buy_amount = allocation / float(exchange.fetch_ticker(k)['info']['lastPrice'])
-            exchange.create_market_buy_order(k, round(buy_amount,2))
-            print(f'Bought {k}')
-            v['in position'] = True
-            
-            
-
-def while_trading(dict3,allocation):
-    for k,v in dict3.items():
-        current = len(v['info'].index) - 1    
-        previous = current - 1
-        previous_2 = current - 2
-        next1 = current + 1
-        
-
-        if v['in position'] and v['info']['lowerband2'][current] == v['info']['lowerband2'][previous] and v['info']['lowerband2'][current] == v['info']['lowerband2'][previous_2]:
-            sell_downtrend = exchange.fetch_balance()['free'][k.split('/')[0]]
-            exchange.create_market_sell_order(k, sell_downtrend)
-            print(f'Sold {k}')
-            v['in position'] = False
-            
-    
-                    
-        elif not v['in position'] and v['info']['lowerband2'][current] > v['info']['lowerband2'][previous] and v['info']['in_uptrend2'][current] and v['info']['in_uptrend2'][previous] and v['info']['close'][current] > v['info']['ewma'][current]:
-            buy_amount = allocation / float(exchange.fetch_ticker(k)['info']['lastPrice'])
-            exchange.create_market_buy_order(k, round(buy_amount,2))
-            print(f'Bought {k}')
-            v['in position'] = True
-
-
-
-def save_trading(dict1):
-
-    with open('trading.p', 'wb') as fp:
-        pickle.dump(dict1, fp, protocol=pickle.HIGHEST_PROTOCOL)
-        print('saved! See you in an hour!')
-
-def which_trades(dict1):
-    list1 = []
-    
-    for k,v in dict1.items():
-        if v['in position'] :
-           list1.append(k) 
-
-    if len(list1) == 0:
-        print('We are trading nothing!')  
-    else:
-        print(f"We are trading {', '.join(list1)} right now!")
-
-    def run_continuously(interval=1):
-        """Continuously run, while executing pending jobs at each
-        elapsed time interval.
-        @return cease_continuous_run: threading. Event which can
-        be set to cease continuous run. Please note that it is
-        *intended behavior that run_continuously() does not run
-        missed jobs*. For example, if you've registered a job that
-        should run every minute and you set a continuous run
-        interval of one hour then your job won't be run 60 times
-        at each interval but only once.
-        """
-        cease_continuous_run = threading.Event()
-
-        class ScheduleThread(threading.Thread):
-            @classmethod
-            def run(cls):
-                while not cease_continuous_run.is_set():
-                    schedule.run_pending()
-                    time.sleep(interval)
-
-        continuous_thread = ScheduleThread()
-        continuous_thread.start()
-        return cease_continuous_run
-
-
-def run_bot():
-
-    if config.IS_TESTNET:
-        trade = ['BTC/USDT', 'ETH/USDT']
-    else:        
-        trade = ['BTC/USDT', 'ETH/USDT', 'BNB/USDT', 
-        'NEO/USDT', 'LTC/USDT', 'QTUM/USDT', 'ADA/USDT', 'XRP/USDT', 
-        'EOS/USDT','LINK/USDT','VET/USDT','MATIC/USDT','DOGE/USDT','DOT/USDT', 
-        'LUNA/USDT', 'RSR/USDT','SHIB/USDT','ZIL/USDT', 'ZRX/USDT','ETC/USDT','BAKE/USDT',
-        'SOL/USDT','THETA/USDT', 'ENJ/USDT','DASH/USDT','KSM/USDT','SUPER/USDT','SUSHI/USDT','XLM/USDT',
-        'BADGER/USDT', 'CKB/USDT', 'ICP/USDT', 'IOTA/USDT', 'ALGO/USDT','MKR/USDT','BCH/USDT','SAND/USDT', 
-        'CAKE/USDT','AAVE/USDT', 'KAVA/USDT', 'TFUEL/USDT', 'ONE/USDT', 'FIL/USDT', 'UNI/USDT', 'XMR/USDT', 'BAT/USDT','CTXC/USDT','GBP/USDT','BAR/USDT']
-
-    tradable_market = tradable_markets(trade)
-
-    #trading = tradings(tradable_market)
-
-    trading1 = remove_downtrend(tradable_market)
-
-    #trading_length = length(trading1)
-
-    #new_trading = new_trades(dict1=tradable_market, dict2=trading1)
-
-    allocation = allocations(list1=trade)
-
-    while_trading_sell(trading1)
-
-    porfolio_management(trading1, allocation=allocation)
-
-    while_trading_buy(trading1,allocation=allocation)
-
-    #while_trading(trading1,allocation=allocation)
-
-    save_trading(trading1)
-
-    which_trades(trading1)
-    
-    return trading1, allocation
-   
-
-
-
-schedule.every().hour.at(":00").do(run_bot)
-#schedule.every(1).minutes.do(run_bot)
-
-
-while True:
-    schedule.run_pending()
-    time.sleep(1)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Fix EMA span (ewm(span=200) instead of ewm(200) which set com).
- Fix chained-assignment SettingWithCopyWarning in supertrend loop by
  operating on numpy arrays and assigning columns once.
- Use Wilder's smoothing for ATR (EMA alpha=1/period) instead of SMA.
- Replace broken new_trades check (list literal) with proper trend logic.
- Move API keys to environment variables; no secrets in tracked files.
- Wrap all ccxt calls in try/except with structured logging.
- Use exchange.amount_to_precision for order sizing.
- Use math.isclose for float-equal sell trigger.
- Replace pickle state with JSON positions file; only persist booleans.
- Drop dead code (get_market, tradings, new_trades, while_trading,
  nested run_continuously) and unused imports.
- Fix allocation divide-by-zero (was len(list)-14).
- Configure spot trading and rate limiting on both testnet and prod.
- Add .gitignore for state files, env, and caches.
- Pin runtime deps in requirements.txt and remove stdlib entries.